### PR TITLE
Fixing height glitch.

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -557,6 +557,7 @@ p.description
   padding-top: 1em
   border-top: 1px solid darken($gray, 10%)
   color: #404040
+  min-height: 28px
   .icon-chat
     color: darken($gray, 15%)
     line-height: normal


### PR DESCRIPTION
Hi!
So, when hovering the home page items under "Campanhas recentes", some rows get messed up.
Is anyone else experiencing this?
![selection_007](https://f.cloud.github.com/assets/461771/1012469/900dbfe2-0b70-11e3-9344-f972be938558.png)

The height of the hidden "Pressionar" button is what's causing this unexpected behavior: there's a one pixel difference. I fixed the glitch by making the parent element min-height: 28px (the height of the button).
Great work, btw!
Felipe. 
